### PR TITLE
Logging requests and their content while redacting passwords

### DIFF
--- a/Coyote/CoyoteNETCore.Runner/Program.cs
+++ b/Coyote/CoyoteNETCore.Runner/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Coyote.NETCore
 {
@@ -12,6 +13,10 @@ namespace Coyote.NETCore
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+            .ConfigureLogging((context, logging) =>
+            {
+                logging.ClearProviders();
+            })
+            .UseStartup<Startup>();
     }
 }

--- a/Coyote/CoyoteNETCore.Runner/RequestResponseLoggingMiddleware.cs
+++ b/Coyote/CoyoteNETCore.Runner/RequestResponseLoggingMiddleware.cs
@@ -53,8 +53,13 @@ namespace Coyote.NETCore
             return $"{request.Scheme.ToUpper()}/{request.Method} {request.Host}{request.Path} {request.QueryString} {bodyAsText}";
         }
 
-        private static string PreventPasswordsFromBeingLogged(PathString requestPath, string bodyAsText)
+        public static string PreventPasswordsFromBeingLogged(PathString requestPath, string bodyAsText)
         {
+            // this method will not work if there's more than 1 'Password' being sent.
+
+            if (bodyAsText is null)
+                return "";
+
             var protected_endspoints = new[] { "/Account/Login", "/Account/Register" };
 
             var removePassword = protected_endspoints.Any(x => requestPath.Value.StartsWith(x, StringComparison.OrdinalIgnoreCase));

--- a/Coyote/CoyoteNETCore.Runner/RequestResponseLoggingMiddleware.cs
+++ b/Coyote/CoyoteNETCore.Runner/RequestResponseLoggingMiddleware.cs
@@ -22,6 +22,9 @@ namespace Coyote.NETCore
         {
             // https://exceptionnotfound.net/using-middleware-to-log-requests-and-responses-in-asp-net-core/
             var request = await FormatRequest(context.Request);
+            Console.WriteLine(request);
+            Console.WriteLine();
+
             var originalBodyStream = context.Response.Body;
             using (var responseBody = new MemoryStream())
             {
@@ -29,9 +32,7 @@ namespace Coyote.NETCore
                 await _next(context);
                 var response = await FormatResponse(context.Response);
                 await responseBody.CopyToAsync(originalBodyStream);
-                Console.WriteLine(response);
             }
-            Console.WriteLine(request);
         }
 
         private async Task<string> FormatRequest(HttpRequest request)
@@ -56,12 +57,14 @@ namespace Coyote.NETCore
             if (removePassword)
             {
                 const string json_property_name = "Password\":\"";
-                var indexOfPassword = bodyAsText.IndexOf(json_property_name) + json_property_name.Length;
-                var nextIndex = bodyAsText.IndexOf('"', indexOfPassword);
+                var indexOfPassword = bodyAsText.IndexOf(json_property_name);
 
-                if (indexOfPassword != -1 && nextIndex != -1)
+                if (indexOfPassword != -1)
                 {
-                    bodyAsText = bodyAsText.ReplaceAt(indexOfPassword, nextIndex-indexOfPassword, "redacted");
+                    var nextIndex = bodyAsText.IndexOf('"', indexOfPassword);
+                    
+                    if (nextIndex != -1)
+                        bodyAsText = bodyAsText.ReplaceAt(indexOfPassword + json_property_name.Length, nextIndex-indexOfPassword, "redacted");
                 }
             }
 

--- a/Coyote/CoyoteNETCore.Runner/RequestResponseLoggingMiddleware.cs
+++ b/Coyote/CoyoteNETCore.Runner/RequestResponseLoggingMiddleware.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CoyoteNETCore.Shared.Extensions;
+
+namespace Coyote.NETCore
+{
+    public class RequestResponseLoggingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public RequestResponseLoggingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            // https://exceptionnotfound.net/using-middleware-to-log-requests-and-responses-in-asp-net-core/
+            var request = await FormatRequest(context.Request);
+            var originalBodyStream = context.Response.Body;
+            using (var responseBody = new MemoryStream())
+            {
+                context.Response.Body = responseBody;
+                await _next(context);
+                var response = await FormatResponse(context.Response);
+                await responseBody.CopyToAsync(originalBodyStream);
+                Console.WriteLine(response);
+            }
+            Console.WriteLine(request);
+        }
+
+        private async Task<string> FormatRequest(HttpRequest request)
+        {
+            request.EnableRewind();
+            var buffer = new byte[Convert.ToInt32(request.ContentLength)];
+            await request.Body.ReadAsync(buffer, 0, buffer.Length);
+            var bodyAsText = Encoding.UTF8.GetString(buffer);
+            request.Body.Position = 0; // allows framework to process this body once again
+
+            bodyAsText = PreventPasswordsFromBeingLogged(request.Path, bodyAsText);
+
+            return $"{request.Scheme.ToUpper()}/{request.Method} {request.Host}{request.Path} {request.QueryString} {bodyAsText}";
+        }
+
+        private static string PreventPasswordsFromBeingLogged(PathString requestPath, string bodyAsText)
+        {
+            var protected_endspoints = new[] { "/Account/Login", "/Account/Register" };
+
+            var removePassword = protected_endspoints.Any(x => requestPath.Value.StartsWith(x, StringComparison.OrdinalIgnoreCase));
+
+            if (removePassword)
+            {
+                const string json_property_name = "Password\":\"";
+                var indexOfPassword = bodyAsText.IndexOf(json_property_name) + json_property_name.Length;
+                var nextIndex = bodyAsText.IndexOf('"', indexOfPassword);
+
+                if (indexOfPassword != -1 && nextIndex != -1)
+                {
+                    bodyAsText = bodyAsText.ReplaceAt(indexOfPassword, nextIndex-indexOfPassword, "redacted");
+                }
+            }
+
+            return bodyAsText;
+        }
+
+        private async Task<string> FormatResponse(HttpResponse response)
+        {
+            response.Body.Seek(0, SeekOrigin.Begin);
+            string text = await new StreamReader(response.Body).ReadToEndAsync();
+            response.Body.Seek(0, SeekOrigin.Begin);
+            return $"{response.StatusCode}: {text}";
+        }
+    }
+}

--- a/Coyote/CoyoteNETCore.Runner/Startup.cs
+++ b/Coyote/CoyoteNETCore.Runner/Startup.cs
@@ -79,7 +79,7 @@ namespace Coyote.NETCore
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, Context context)
         {
             // in order to setup this project easier
-           context.Database.EnsureCreated();
+            context.Database.EnsureCreated();
 
             app.UseForwardedHeaders(new ForwardedHeadersOptions
             {
@@ -106,7 +106,7 @@ namespace Coyote.NETCore
             });
 
             //app.UseHttpsRedirection();
-
+            app.UseMiddleware<RequestResponseLoggingMiddleware>();
             app.UseAuthentication();
             app.UseMvc();
         }

--- a/Coyote/CoyoteNETCore.Runner/appsettings.json
+++ b/Coyote/CoyoteNETCore.Runner/appsettings.json
@@ -14,7 +14,7 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "3"
     }
   },
   "AllowedHosts": "*"

--- a/Coyote/CoyoteNETCore.Shared/Extensions/String.cs
+++ b/Coyote/CoyoteNETCore.Shared/Extensions/String.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace CoyoteNETCore.Shared.Extensions
+{
+    public static class String
+    {
+        public static string ReplaceAt(this string str, int index, int length, string replace)
+        {
+            return str.Remove(index, Math.Min(length, str.Length - index))
+                    .Insert(index, replace);
+        }
+    }
+}

--- a/Coyote/CoyoteNETCore.Tests/LoggerTests.cs
+++ b/Coyote/CoyoteNETCore.Tests/LoggerTests.cs
@@ -1,0 +1,102 @@
+﻿using Coyote.NETCore;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace CoyoteNETCore.Tests
+{
+    public class LoggerTests
+    {
+        [Fact]
+        public void RedactingPassword()
+        {
+            var uri = new PathString("/Account/Login");
+            var payload = JsonConvert.SerializeObject(new { Username = "test6", Password = "password", Email = "test7@test.pl" });
+            Assert.Contains("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("password", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload)); 
+
+            payload = JsonConvert.SerializeObject(new { Username = "test6", Password = "asdf", Email = "test7@test.pl" });
+            Assert.Contains("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("asdf", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload)); 
+
+            payload = "{\"Password\":\"qwe\"}}";
+            Assert.Contains("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = "{\"Password\":\"qwe}}";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.Contains("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = "";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = null;
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+        }
+
+        [Fact]
+        public void RedactingPassword2()
+        {
+            var uri = new PathString("/Account/Register");
+
+            var payload = JsonConvert.SerializeObject(new { Username = "test6", Password = "password", Email = "test7@test.pl" });
+            Assert.Contains("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("password", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload)); 
+
+            payload = JsonConvert.SerializeObject(new { Username = "test6", Password = "asdf", Email = "test7@test.pl" });
+            Assert.Contains("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("asdf", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload)); 
+
+            payload = "{\"Password\":\"qwe\"}}";
+            Assert.Contains("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = "{\"Password\":\"qwe}}";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.Contains("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = "";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = null;
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+        }
+
+        [Fact]
+        public void NotRedactingPassword()
+        {
+            var uri = new PathString("/Account/Asd");
+
+            var payload = JsonConvert.SerializeObject(new { Username = "test6", Password = "password", Email = "test7@test.pl" });
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.Contains("password", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload)); 
+
+            payload = JsonConvert.SerializeObject(new { Username = "test6", Password = "asdf", Email = "test7@test.pl" });
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.Contains("asdf", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload)); 
+
+            payload = "{\"Password\":\"qwe\"}}";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.Contains("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = "{\"Password\":\"qwe}}";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.Contains("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = "";
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+
+            payload = null;
+            Assert.DoesNotContain("redacted", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+            Assert.DoesNotContain("qwe", RequestResponseLoggingMiddleware.PreventPasswordsFromBeingLogged(uri, payload));
+        }
+    }
+}


### PR DESCRIPTION
Sample log:

```
HTTP/POST localhost/Account/Register  {"Username":"test8","Password":"redacted","Email":"test8@test.pl"}
HTTP/POST localhost/Account/Register  {"Username":"Xtest8X","Password":"redacted","Email":"test9@test.pl"}
HTTP/POST localhost/Account/Register  {"Username":"test2","Password":"redacted","Email":"test2@test.pl"}
HTTP/POST localhost/Account/Register  {"Username":"test2","Password":"redacted","Email":"test3@test.pl"}
HTTP/POST localhost/Account/Register  {"Username":"test","Password":"redacted"}
```